### PR TITLE
Connect calendar to C++ backend

### DIFF
--- a/src/components/calendar/CalendarPage.tsx
+++ b/src/components/calendar/CalendarPage.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { ChevronLeft, ChevronRight, Calendar, Grid3x3, List, Plus } from 'lucide-react';
 import DayView from './DayView';
@@ -9,37 +9,14 @@ import AddEventModal from './AddEventModal';
 import EventDetailModal from './EventDetailModal';
 import HoverTooltip from './HoverTooltip';
 import { CalendarEvent, Slot } from './types';
-
-// Mock API call - replace with your actual API
-const fetchEvents = async (): Promise<CalendarEvent[]> => {
-  await new Promise((resolve) => setTimeout(resolve, 300));
-  return [
-    {
-      id: 1,
-      title: 'Server Maintenance',
-      start: new Date(2024, 0, 15, 10, 0),
-      end: new Date(2024, 0, 15, 12, 0),
-      color: '#3b82f6',
-      description: 'Routine server updates and optimization',
-    },
-    {
-      id: 2,
-      title: 'AI Model Training',
-      start: new Date(2024, 0, 16, 14, 0),
-      end: new Date(2024, 0, 16, 18, 0),
-      color: '#8b5cf6',
-      description: 'Training new neural network models',
-    },
-    {
-      id: 3,
-      title: 'Data Sync',
-      start: new Date(2024, 0, 17, 9, 0),
-      end: new Date(2024, 0, 17, 10, 30),
-      color: '#06b6d4',
-      description: 'Cross-server data synchronization',
-    },
-  ];
-};
+import {
+  getDayEvents,
+  getWeekEvents,
+  getMonthEvents,
+  createEvent,
+  deleteEvent,
+  getNextEvent,
+} from '@/lib/api';
 
 const CalendarPage = () => {
   const [view, setView] = useState<'day' | 'week' | 'month'>('week');
@@ -58,10 +35,32 @@ const CalendarPage = () => {
     endTime: '10:00',
     color: '#3b82f6',
   });
+  const [nextEvent, setNextEvent] = useState<CalendarEvent | null>(null);
+
+  const loadEvents = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      if (view === 'day') {
+        const dateStr = currentDate.toISOString().split('T')[0];
+        setEvents(await getDayEvents(dateStr));
+      } else if (view === 'week') {
+        const dateStr = currentDate.toISOString().split('T')[0];
+        setEvents(await getWeekEvents(dateStr));
+      } else {
+        const month = currentDate.toISOString().slice(0, 7);
+        setEvents(await getMonthEvents(month));
+      }
+      const ne = await getNextEvent();
+      setNextEvent(ne);
+    } catch (err) {
+      console.error(err);
+    }
+    setIsLoading(false);
+  }, [currentDate, view]);
 
   useEffect(() => {
     loadEvents();
-  }, [currentDate, view]);
+  }, [currentDate, view, loadEvents]);
 
   useEffect(() => {
     const handleMouseMove = (e: MouseEvent) => setMousePos({ x: e.clientX, y: e.clientY });
@@ -69,12 +68,6 @@ const CalendarPage = () => {
     return () => window.removeEventListener('mousemove', handleMouseMove);
   }, []);
 
-  const loadEvents = async () => {
-    setIsLoading(true);
-    const fetchedEvents = await fetchEvents();
-    setEvents(fetchedEvents);
-    setIsLoading(false);
-  };
 
   const getViewStartDate = () => {
     const date = new Date(currentDate);
@@ -117,18 +110,31 @@ const CalendarPage = () => {
     setShowAddEvent(true);
   };
 
-  const handleCreateEvent = () => {
+  const handleDeleteEvent = async (id: string) => {
+    try {
+      await deleteEvent(id);
+      setSelectedEvent(null);
+      loadEvents();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleCreateEvent = async () => {
     const startDate = new Date(`${newEvent.date}T${newEvent.startTime}`);
     const endDate = new Date(`${newEvent.date}T${newEvent.endTime}`);
-    const event: CalendarEvent = {
-      id: Date.now(),
-      title: newEvent.title,
-      description: newEvent.description,
-      start: startDate,
-      end: endDate,
-      color: newEvent.color,
-    };
-    setEvents([...events, event]);
+    try {
+      const created = await createEvent({
+        title: newEvent.title,
+        description: newEvent.description,
+        time: `${newEvent.date} ${newEvent.startTime}`,
+        duration: Math.round((endDate.getTime() - startDate.getTime()) / 1000),
+      });
+      created.color = newEvent.color;
+      setEvents([...events, created]);
+    } catch (err) {
+      console.error(err);
+    }
     setShowAddEvent(false);
     setNewEvent({
       title: '',
@@ -200,6 +206,17 @@ const CalendarPage = () => {
             <span className="text-sm font-medium">Add Event</span>
           </motion.button>
         </div>
+        {nextEvent && (
+          <div className="text-sm text-gray-400 mt-2">
+            Next: {nextEvent.title} at{' '}
+            {nextEvent.start.toLocaleString('en-US', {
+              month: 'short',
+              day: 'numeric',
+              hour: '2-digit',
+              minute: '2-digit',
+            })}
+          </div>
+        )}
       </motion.div>
       <AnimatePresence>
         {isLoading && (
@@ -225,8 +242,18 @@ const CalendarPage = () => {
           )}
         </AnimatePresence>
       </motion.div>
-      <AddEventModal show={showAddEvent} newEvent={newEvent} setNewEvent={setNewEvent} onClose={() => setShowAddEvent(false)} onCreate={handleCreateEvent} />
-      <EventDetailModal event={selectedEvent} onClose={() => setSelectedEvent(null)} />
+      <AddEventModal
+        show={showAddEvent}
+        newEvent={newEvent}
+        setNewEvent={setNewEvent}
+        onClose={() => setShowAddEvent(false)}
+        onCreate={handleCreateEvent}
+      />
+      <EventDetailModal
+        event={selectedEvent}
+        onClose={() => setSelectedEvent(null)}
+        onDelete={handleDeleteEvent}
+      />
       <HoverTooltip slot={hoveredSlot} mousePos={mousePos} show={!!hoveredSlot && !selectedEvent} />
     </div>
   );

--- a/src/components/calendar/EventDetailModal.tsx
+++ b/src/components/calendar/EventDetailModal.tsx
@@ -7,9 +7,10 @@ import { CalendarEvent } from './types';
 interface Props {
   event: CalendarEvent | null;
   onClose: () => void;
+  onDelete: (id: string) => void;
 }
 
-const EventDetailModal: React.FC<Props> = ({ event, onClose }) => (
+const EventDetailModal: React.FC<Props> = ({ event, onClose, onDelete }) => (
   <AnimatePresence>
     {event && (
       <motion.div
@@ -57,7 +58,12 @@ const EventDetailModal: React.FC<Props> = ({ event, onClose }) => (
               <motion.button className="flex-1 py-2 bg-blue-500 hover:bg-blue-600 rounded-lg transition-colors" whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
                 Edit Event
               </motion.button>
-              <motion.button className="flex-1 py-2 bg-red-500/20 hover:bg-red-500/30 text-red-400 rounded-lg transition-colors" whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
+              <motion.button
+                className="flex-1 py-2 bg-red-500/20 hover:bg-red-500/30 text-red-400 rounded-lg transition-colors"
+                whileHover={{ scale: 1.02 }}
+                whileTap={{ scale: 0.98 }}
+                onClick={() => onDelete(event.id)}
+              >
                 Delete
               </motion.button>
             </div>

--- a/src/components/calendar/types.ts
+++ b/src/components/calendar/types.ts
@@ -1,5 +1,5 @@
 export interface CalendarEvent {
-  id: number;
+  id: string;
   title: string;
   start: Date;
   end: Date;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,104 @@
+export interface ApiEvent {
+  id: string;
+  title: string;
+  description: string;
+  time: string; // "YYYY-MM-DD HH:MM"
+  duration: number; // seconds
+}
+
+import { CalendarEvent } from "@/components/calendar/types";
+
+const API_BASE = "http://localhost:8080";
+
+const COLORS = [
+  "#3b82f6",
+  "#8b5cf6",
+  "#06b6d4",
+  "#10b981",
+  "#f59e0b",
+  "#ef4444",
+  "#ec4899",
+];
+
+function colorForId(id: string): string {
+  let hash = 0;
+  for (let i = 0; i < id.length; i++) {
+    hash = (hash + id.charCodeAt(i)) % COLORS.length;
+  }
+  return COLORS[hash];
+}
+
+function parseApiEvent(e: ApiEvent): CalendarEvent {
+  const start = new Date(e.time.replace(" ", "T"));
+  const end = new Date(start.getTime() + e.duration * 1000);
+  return {
+    id: e.id,
+    title: e.title,
+    description: e.description,
+    start,
+    end,
+    color: colorForId(e.id),
+  };
+}
+
+async function handleResponse(res: Response) {
+  const data = await res.json();
+  if (data.status !== "ok") {
+    throw new Error(data.message || "Request failed");
+  }
+  return data.data;
+}
+
+export async function getAllEvents(): Promise<CalendarEvent[]> {
+  const res = await fetch(`${API_BASE}/events`);
+  const data: ApiEvent[] = await handleResponse(res);
+  return data.map(parseApiEvent);
+}
+
+export async function getNextEvent(): Promise<CalendarEvent> {
+  const res = await fetch(`${API_BASE}/events/next`);
+  const data: ApiEvent = await handleResponse(res);
+  return parseApiEvent(data);
+}
+
+export async function getDayEvents(date: string): Promise<CalendarEvent[]> {
+  const res = await fetch(`${API_BASE}/events/day/${date}`);
+  const data: ApiEvent[] = await handleResponse(res);
+  return data.map(parseApiEvent);
+}
+
+export async function getWeekEvents(date: string): Promise<CalendarEvent[]> {
+  const res = await fetch(`${API_BASE}/events/week/${date}`);
+  const data: ApiEvent[] = await handleResponse(res);
+  return data.map(parseApiEvent);
+}
+
+export async function getMonthEvents(month: string): Promise<CalendarEvent[]> {
+  const res = await fetch(`${API_BASE}/events/month/${month}`);
+  const data: ApiEvent[] = await handleResponse(res);
+  return data.map(parseApiEvent);
+}
+
+export interface NewEventData {
+  title: string;
+  description: string;
+  time: string; // YYYY-MM-DD HH:MM
+  duration: number; // seconds
+}
+
+export async function createEvent(newEvent: NewEventData): Promise<CalendarEvent> {
+  const res = await fetch(`${API_BASE}/events`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(newEvent),
+  });
+  const data: ApiEvent = await handleResponse(res);
+  return parseApiEvent(data);
+}
+
+export async function deleteEvent(id: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/events/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+  });
+  await handleResponse(res);
+}


### PR DESCRIPTION
## Summary
- add API helper for all server routes
- load events from backend in calendar page
- allow creating and deleting events via API
- show next event at the top of the calendar
- keep events typed with string ids

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist`)*

------
https://chatgpt.com/codex/tasks/task_e_6841e1f287f0832a9c1d90119f51adeb