### PR TITLE
Convert UTC events to local and show current time

### DIFF
--- a/src/components/calendar/DayView.tsx
+++ b/src/components/calendar/DayView.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { CalendarEvent, Slot } from './types';
 
@@ -19,9 +19,24 @@ const DayView: React.FC<Props> = ({
   setSelectedEvent,
 }) => {
   const hours = Array.from({ length: 24 }, (_, i) => i);
+  const [now, setNow] = useState(new Date());
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 60000);
+    return () => clearInterval(id);
+  }, []);
+
+  const isToday = currentDate.toDateString() === now.toDateString();
+  const currentTop = (now.getHours() + now.getMinutes() / 60) * 64;
 
   return (
     <div className="relative">
+      {isToday && (
+        <div
+          className="absolute left-20 right-0 h-px bg-red-500 z-20"
+          style={{ top: currentTop }}
+        />
+      )}
       <div className="grid grid-cols-[80px_1fr] gap-0">
         {hours.map((hour) => (
           <React.Fragment key={hour}>

--- a/src/components/calendar/WeekView.tsx
+++ b/src/components/calendar/WeekView.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { CalendarEvent, Slot } from './types';
 
@@ -28,8 +28,26 @@ const WeekView: React.FC<Props> = ({
     return date;
   });
 
+  const [now, setNow] = useState(new Date());
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 60000);
+    return () => clearInterval(id);
+  }, []);
+
+  const weekStart = new Date(start);
+  const weekEnd = new Date(start.getTime() + 7 * 24 * 60 * 60 * 1000);
+  const isCurrentWeek = now >= weekStart && now < weekEnd;
+  const currentTop = (now.getHours() + now.getMinutes() / 60) * 64;
+
   return (
     <div className="relative overflow-x-auto">
+      {isCurrentWeek && (
+        <div
+          className="absolute left-20 right-0 h-px bg-red-500 z-20"
+          style={{ top: currentTop }}
+        />
+      )}
       <div className="grid grid-cols-[80px_repeat(7,1fr)] gap-0 min-w-[800px]">
         <div></div>
         {days.map((d, i) => (

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -29,7 +29,9 @@ function colorForId(id: string): string {
 }
 
 function parseApiEvent(e: ApiEvent): CalendarEvent {
-  const start = new Date(e.time.replace(" ", "T"));
+  // Dates from the server are in UTC. Append a 'Z' so the browser parses the
+  // timestamp as UTC before converting it to the local timezone.
+  const start = new Date(e.time.replace(" ", "T") + "Z");
   const end = new Date(start.getTime() + e.duration * 1000);
   return {
     id: e.id,


### PR DESCRIPTION
## Summary
- parse event times from API as UTC so browsers convert to local
- add current time indicator to the day and week calendar views

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68423d66636c832a8d439ac63fb775f0