### PR TITLE
Add responsive top navbar

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import Navbar from "@/components/Navbar";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +28,8 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <Navbar />
+        <main className="pt-16">{children}</main>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,6 @@ import React, { useState, useEffect, useRef } from 'react';
 import ParticleField from '@/components/ParticleField';
 import JarvisOrb from '@/components/JarvisOrb';
 import InputSection from '@/components/InputSection';
-import Link from 'next/link';
 
 
 
@@ -64,12 +63,6 @@ const JarvisInterface = () => {
       {/* Deep space background */}
       <div className="fixed inset-0 bg-gradient-to-b from-gray-900 via-black to-blue-950 opacity-50" />
 
-      <Link
-        href="/calendar"
-        className="absolute top-4 right-4 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-500"
-      >
-        Calendar
-      </Link>
 
       <ParticleField />
       <div className="w-full h-full absolute top-0 left-0 pointer-events-none flex items-center justify-center">

--- a/src/app/protocols/page.tsx
+++ b/src/app/protocols/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+export default function ProtocolsPage() {
+  return (
+    <div className="mx-auto max-w-4xl p-6 text-center">
+      <h1 className="text-3xl font-semibold mb-4">Protocols</h1>
+      <p className="text-gray-600 dark:text-gray-300">
+        This is a placeholder for protocols management.
+      </p>
+    </div>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,66 @@
+'use client';
+import { useState } from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { Menu } from 'lucide-react';
+
+const navItems = [
+  { href: '/calendar', label: 'Calendar' },
+  { href: '/protocols', label: 'Protocols' },
+];
+
+export default function Navbar() {
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <nav className="fixed top-0 left-0 right-0 z-50 bg-gray-900 text-white border-b border-gray-800">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="flex h-16 items-center justify-between">
+          <div className="text-lg font-semibold">Jarvis Dashboard</div>
+          <div className="hidden md:flex space-x-4">
+            {navItems.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={`px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+                  pathname.startsWith(item.href)
+                    ? 'bg-gray-800'
+                    : 'hover:bg-gray-700 focus:bg-gray-700'
+                }`}
+              >
+                {item.label}
+              </Link>
+            ))}
+          </div>
+          <div className="md:hidden">
+            <button
+              className="p-2 rounded-md hover:bg-gray-700 focus:bg-gray-700"
+              onClick={() => setOpen(!open)}
+            >
+              <Menu size={20} />
+            </button>
+          </div>
+        </div>
+      </div>
+      {open && (
+        <div className="md:hidden border-t border-gray-800 bg-gray-900">
+          {navItems.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              onClick={() => setOpen(false)}
+              className={`block px-4 py-2 text-sm transition-colors ${
+                pathname.startsWith(item.href)
+                  ? 'bg-gray-800'
+                  : 'hover:bg-gray-700 focus:bg-gray-700'
+              }`}
+            >
+              {item.label}
+            </Link>
+          ))}
+        </div>
+      )}
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce `Navbar` component with responsive menu and active link styles
- mount navbar globally in `layout.tsx` and pad main area
- add Protocols page as placeholder
- clean up home page calendar link

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts, missing @react-three/* deps)*

------
https://chatgpt.com/codex/tasks/task_e_686555feea08832aa7c445b09307950a