### PR TITLE
Add basic auth gate

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-import Navbar from "@/components/Navbar";
+import Providers from "./providers";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -25,11 +25,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        <Navbar />
-        <main className="pt-16">{children}</main>
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <Providers>
+          <main className="pt-16">{children}</main>
+        </Providers>
       </body>
     </html>
   );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,73 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/components/auth/AuthProvider';
+
+export default function LoginPage() {
+  const { setToken } = useAuth();
+  const router = useRouter();
+  const [mode, setMode] = useState<'login' | 'signup'>('login');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const endpoint = mode === 'signup' ? 'signup' : 'login';
+    try {
+      const res = await fetch(`http://localhost:8000/${endpoint}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      });
+      const data = await res.json();
+      if (res.ok && data.token) {
+        setToken(data.token as string);
+        router.push('/');
+      } else {
+        setError(data.error || 'Authentication failed');
+      }
+    } catch {
+      setError('Network error');
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-black text-white">
+      <form onSubmit={handleSubmit} className="space-y-4 bg-slate-900 p-6 rounded-lg border border-cyan-500/20 w-80">
+        <h1 className="text-center text-xl font-mono text-cyan-400">
+          {mode === 'login' ? 'Login' : 'Sign Up'}
+        </h1>
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="Email"
+          required
+          className="w-full px-3 py-2 bg-black border border-cyan-400/20 rounded"
+        />
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+          required
+          className="w-full px-3 py-2 bg-black border border-cyan-400/20 rounded"
+        />
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+        <button type="submit" className="w-full py-2 bg-cyan-600 hover:bg-cyan-700 rounded">
+          {mode === 'login' ? 'Login' : 'Create Account'}
+        </button>
+        <p className="text-center text-sm">
+          {mode === 'login' ? 'No account?' : 'Already have an account?'}{' '}
+          <span
+            onClick={() => setMode(mode === 'login' ? 'signup' : 'login')}
+            className="text-cyan-400 cursor-pointer underline"
+          >
+            {mode === 'login' ? 'Sign up' : 'Login'}
+          </span>
+        </p>
+      </form>
+    </div>
+  );
+}

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,0 +1,18 @@
+'use client';
+import { usePathname } from 'next/navigation';
+import Navbar from '@/components/Navbar';
+import { AuthProvider } from '@/components/auth/AuthProvider';
+import AuthGuard from '@/components/auth/AuthGuard';
+
+export default function Providers({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const showNavbar = pathname !== '/login';
+  return (
+    <AuthProvider>
+      <AuthGuard>
+        {showNavbar && <Navbar />}
+        {children}
+      </AuthGuard>
+    </AuthProvider>
+  );
+}

--- a/src/components/auth/AuthGuard.tsx
+++ b/src/components/auth/AuthGuard.tsx
@@ -1,0 +1,25 @@
+'use client';
+import { useEffect } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+import { useAuth } from './AuthProvider';
+
+export default function AuthGuard({ children }: { children: React.ReactNode }) {
+  const { token } = useAuth();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (!token && pathname !== '/login') {
+      router.replace('/login');
+    }
+    if (token && pathname === '/login') {
+      router.replace('/');
+    }
+  }, [token, pathname, router]);
+
+  if (!token && pathname !== '/login') {
+    return null;
+  }
+
+  return <>{children}</>;
+}

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -1,0 +1,38 @@
+'use client';
+import React, { createContext, useContext, useState, useEffect } from 'react';
+
+interface AuthContextValue {
+  token: string | null;
+  setToken: (token: string | null) => void;
+}
+
+const AuthContext = createContext<AuthContextValue>({
+  token: null,
+  setToken: () => {},
+});
+
+export const useAuth = () => useContext(AuthContext);
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [token, setTokenState] = useState<string | null>(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('authToken');
+    if (stored) setTokenState(stored);
+  }, []);
+
+  const setToken = (value: string | null) => {
+    if (value) {
+      localStorage.setItem('authToken', value);
+    } else {
+      localStorage.removeItem('authToken');
+    }
+    setTokenState(value);
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, setToken }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};


### PR DESCRIPTION
## Summary
- implement a simple `AuthProvider` and `AuthGuard`
- hide all pages behind login
- create login/signup screen
- wire providers in `layout.tsx`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686c9ea0bf24832aad7dcc8b14ddfab9